### PR TITLE
Update Clear-LocalHybridWorkerConfiguration.ps1

### DIFF
--- a/Clear-LocalHybridWorkerConfiguration.ps1
+++ b/Clear-LocalHybridWorkerConfiguration.ps1
@@ -71,7 +71,7 @@ process {
         $StartedServiceStatus = (Get-Service -Name HealthService).Status
     } until ($StartedServiceStatus -eq "Running" -or (New-TimeSpan -End $StartingServiceTime))
 
-    Write-Host "HealtService is now $($StartedServiceStatus.toLower()) , SCOM monitoring will be resumed as well." -ForegroundColor Green
+    Write-Host "HealtService is now $($StartedServiceStatus) , SCOM monitoring will be resumed as well." -ForegroundColor Green
 }
 
 


### PR DESCRIPTION
Removed `.tolower()` because on Win 2019 at least the service status is returned as a `System.ServiceProcess.ServiceControllerStatus` and doesn't have a `tolower()` method.

Thanks for this script, worked a treat for my issues!